### PR TITLE
replace archived rust toolchain actions

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -27,12 +27,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: true
 
+
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: hecrj/setup-rust-action@v2
         with:
-          profile: minimal
-          override: true
-          toolchain: ${{ matrix.toolchain }}
+          rust-version: ${{ matrix.toolchain }}
+          targets: ${{ matrix.target }}
           components: rustfmt, clippy
 
       - name: Show Rust toolchain version
@@ -51,11 +51,6 @@ jobs:
       - name: Setup protobuf
         shell: bash
         run: sudo apt -y install protobuf-compiler
-
-      - name: Add target
-        uses: ./.github/actions/add-target
-        with:
-          target: ${{ matrix.target }}
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,22 +28,16 @@ jobs:
           submodules: true
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: hecrj/setup-rust-action@v2
         with:
-          profile: minimal
-          override: true
-          toolchain: ${{ matrix.toolchain }}
+          rust-version: ${{ matrix.toolchain }}
+          targets: ${{ matrix.target }}
           components: rustfmt, clippy
 
       # - name: Setup musl-tools
       #   if: matrix.target == 'x86_64-unknown-linux-musl'
       #   shell: bash
       #   run: sudo apt -y install musl-tools
-
-      - name: Add target
-        uses: ./.github/actions/add-target
-        with:
-          target: ${{ matrix.target }}
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
The action we currently use to setup rust toolchain, actions-rs/toolchain, haven't updated for almost 4 years now, and have been archived by it's author, we should switch to a more active action.