### PR TITLE
update ci os config

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # we only need to support linux
-        os: [ ubuntu-22.04, ubuntu-latest ]
+        os: [ ubuntu-20.04, ubuntu-latest ]
         # TODO: do we want to support musl?
         target: [ x86_64-unknown-linux-gnu ]
         # make sure it runs on latest stable & nightly rust in development build

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # we only need to support linux
-        os: [ ubuntu-22.04, ubuntu-latest ]
+        os: [ ubuntu-20.04, ubuntu-latest ]
         # TODO: do we want to support musl?
         target: [ x86_64-unknown-linux-gnu ]
         # make sure it runs on latest stable rust


### PR DESCRIPTION
Right now ubuntu-latest is actually ubuntu-22.04, so we use 20.04 & latest instead.