### PR TITLE
Enable TLS support for gRPC connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,6 +1616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "opentelemetry"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2125,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2167,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2232,38 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "schannel"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2275,6 +2393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "sptr"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2415,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2444,6 +2574,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,8 +2663,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "socket2",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -2690,6 +2834,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3519,6 +3669,12 @@ dependencies = [
  "quote",
  "syn 2.0.66",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ host-op-system = { workspace = true }
 psh-system = { workspace = true }
 opentelemetry-otlp = { workspace = true, features = [
   "metrics",
+  "tls-roots",
   "opentelemetry-http",
   "http-proto",
   "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 
 [dependencies]
 clap = { workspace = true, features = ["derive", "wrap_help"] }
-tonic = { workspace = true }
+tonic = { workspace = true, features = ["tls-roots"] }
 prost = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 nix = { workspace = true, features = ["user", "hostname"] }

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -18,13 +18,14 @@ use opentelemetry_sdk::{
 use psh_system::{
     disk::DiskHandle, interrupt::InterruptHandle, memory::MemoryHandle, network::NetworkHandle,
 };
-use tonic::metadata::MetadataMap;
+use tonic::{metadata::MetadataMap, transport::ClientTlsConfig};
 
 pub fn meter_provider(export_config: ExportConfig, token: String) -> Result<SdkMeterProvider> {
     let mut meta = MetadataMap::new();
     meta.insert("authorization", format!("Bearer {}", token).parse()?);
     let otlp_exporter = opentelemetry_otlp::new_exporter()
         .tonic()
+        .with_tls_config(ClientTlsConfig::new().with_native_roots())
         .with_metadata(meta)
         .with_export_config(export_config);
 

--- a/src/services/rpc.rs
+++ b/src/services/rpc.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 // Copyright (c) 2023-2024 Optimatist Technology Co., Ltd. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
@@ -14,7 +12,8 @@ use std::time::Duration;
 // You should have received a copy of the GNU Lesser General Public License along with Performance Savior Home (PSH). If not,
 // see <https://www.gnu.org/licenses/>.
 use anyhow::Result;
-use tonic::Request;
+use std::time::Duration;
+use tonic::{transport::Channel, Request};
 
 use crate::services::{
     host_info::RawInfo,
@@ -26,15 +25,14 @@ use super::config::RpcConfig;
 #[derive(Clone, Debug)]
 pub struct RpcClient {
     token: String,
-    client: PshServiceClient<tonic::transport::Channel>,
+    client: PshServiceClient<Channel>,
     raw_info: RawInfo,
     duration: Duration,
 }
 
 impl RpcClient {
     pub async fn new(config: RpcConfig, token: String) -> Result<Self> {
-        let client: PshServiceClient<tonic::transport::Channel> =
-            PshServiceClient::connect(config.addr).await?;
+        let client: PshServiceClient<Channel> = PshServiceClient::connect(config.addr).await?;
         let raw_info = RawInfo::new();
         Ok(Self {
             duration: Duration::from_secs(config.duration),
@@ -103,7 +101,7 @@ mod rpc_tests {
     use std::{future::Future, net::Ipv4Addr};
 
     use tokio::sync::oneshot;
-    use tonic::transport::Server;
+    use tonic::transport::{Channel, Error, Server};
 
     use self::psh_service_client::PshServiceClient;
     use crate::{
@@ -183,8 +181,7 @@ mod rpc_tests {
         Ok(())
     }
 
-    type ClientChannelResult =
-        Result<PshServiceClient<tonic::transport::Channel>, tonic::transport::Error>;
+    type ClientChannelResult = Result<PshServiceClient<Channel>, Error>;
     async fn test_heartbeat(client: impl Future<Output = ClientChannelResult>) {
         let info: HostInfoRequest = RawInfo::new().into();
         let resp = client.await.unwrap().send_host_info(info).await.unwrap();

--- a/src/services/rpc.rs
+++ b/src/services/rpc.rs
@@ -13,7 +13,10 @@
 // see <https://www.gnu.org/licenses/>.
 use anyhow::Result;
 use std::time::Duration;
-use tonic::{transport::Channel, Request};
+use tonic::{
+    transport::{Channel, ClientTlsConfig, Endpoint},
+    Request,
+};
 
 use crate::services::{
     host_info::RawInfo,
@@ -32,7 +35,9 @@ pub struct RpcClient {
 
 impl RpcClient {
     pub async fn new(config: RpcConfig, token: String) -> Result<Self> {
-        let client: PshServiceClient<Channel> = PshServiceClient::connect(config.addr).await?;
+        let ep = Endpoint::from_shared(config.addr)?
+            .tls_config(ClientTlsConfig::new().with_native_roots())?;
+        let client: PshServiceClient<Channel> = PshServiceClient::connect(ep).await?;
         let raw_info = RawInfo::new();
         Ok(Self {
             duration: Duration::from_secs(config.duration),


### PR DESCRIPTION
This fixes the "Connecting to HTTPS without TLS enabled" error when connecting to https addresses.