### PR TITLE
Contains `instance_id` in gauges

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,12 @@ mod security;
 mod services;
 mod utils;
 
-use std::{process::exit, result::Result::Ok, thread::JoinHandle};
+use std::{
+    fs::{self},
+    process::exit,
+    result::Result::Ok,
+    thread::JoinHandle,
+};
 
 use anyhow::{Context, Error, Result};
 use args::Args;
@@ -36,7 +41,7 @@ use runtime::PshEngineBuilder;
 use utils::check_root_privilege;
 
 use otlp::config::OtlpConfig;
-use services::{config::RpcConfig, rpc::RpcClient};
+use services::{config::RpcConfig, host_info::RawInfo, rpc::RpcClient};
 
 fn main() -> Result<()> {
     log_init();
@@ -104,7 +109,10 @@ fn async_tasks(
             let otlp_task = async {
                 if otlp_conf.enable() {
                     let export_conf: ExportConfig = otlp_conf.into();
-                    otlp::otlp_tasks(export_conf, token).await?;
+                    let instance_id = fs::read_to_string(RawInfo::INSTANCE_ID_FILE)
+                        .map(Some)
+                        .unwrap_or(None);
+                    otlp::otlp_tasks(instance_id, export_conf, token).await?;
                 }
                 Ok::<(), Error>(())
             };

--- a/src/otlp/gauges/disk.rs
+++ b/src/otlp/gauges/disk.rs
@@ -1,0 +1,145 @@
+use std::{borrow::Cow, time::Duration};
+
+use opentelemetry::{
+    metrics::{Meter, ObservableGauge},
+    KeyValue,
+};
+use psh_system::disk::DiskHandle;
+
+pub fn start(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
+    let disk = DiskHandle::new();
+    let gauge = meter
+        .u64_observable_gauge("DiskStat")
+        .with_description("System profile disk statistics.")
+        // .with_unit(Unit::new("KiB"))
+        .with_callback(move |gauge| {
+            let Ok(disks) = disk.stat(Some(interval)) else {
+                return;
+            };
+            for stat in disks {
+                // TODO
+                let name = Cow::from(stat.name);
+                gauge.observe(
+                    stat.reads,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "reads"),
+                    ],
+                );
+                gauge.observe(
+                    stat.merged,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "merged"),
+                    ],
+                );
+                gauge.observe(
+                    stat.sectors_read,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "sectors_read"),
+                    ],
+                );
+                gauge.observe(
+                    stat.time_reading,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "time_reading"),
+                    ],
+                );
+                gauge.observe(
+                    stat.writes,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "writes"),
+                    ],
+                );
+                gauge.observe(
+                    stat.writes_merged,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "writes_merged"),
+                    ],
+                );
+                gauge.observe(
+                    stat.sectors_written,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "sectors_written"),
+                    ],
+                );
+                gauge.observe(
+                    stat.time_writing,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "time_writing"),
+                    ],
+                );
+                gauge.observe(
+                    stat.in_progress,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "in_progress"),
+                    ],
+                );
+                gauge.observe(
+                    stat.time_in_progress,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "time_in_progress"),
+                    ],
+                );
+                gauge.observe(
+                    stat.weighted_time_in_progress,
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "weighted_time_in_progress"),
+                    ],
+                );
+                gauge.observe(
+                    stat.discards.unwrap_or(0),
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "discards"),
+                    ],
+                );
+                gauge.observe(
+                    stat.discards_merged.unwrap_or(0),
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "discards_merged"),
+                    ],
+                );
+                gauge.observe(
+                    stat.sectors_discarded.unwrap_or(0),
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "sectors_discarded"),
+                    ],
+                );
+                gauge.observe(
+                    stat.time_discarding.unwrap_or(0),
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "time_discarding"),
+                    ],
+                );
+                gauge.observe(
+                    stat.flushes.unwrap_or(0),
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "flushes"),
+                    ],
+                );
+                gauge.observe(
+                    stat.time_flushing.unwrap_or(0),
+                    &[
+                        KeyValue::new("disk", name.clone()),
+                        KeyValue::new("stat", "time_flushing"),
+                    ],
+                );
+            }
+        })
+        .try_init()?;
+    Ok(gauge)
+}

--- a/src/otlp/gauges/disk.rs
+++ b/src/otlp/gauges/disk.rs
@@ -6,7 +6,11 @@ use opentelemetry::{
 };
 use psh_system::disk::DiskHandle;
 
-pub fn start(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
+pub fn start(
+    instance_id: Option<String>,
+    meter: Meter,
+    interval: Duration,
+) -> anyhow::Result<ObservableGauge<u64>> {
     let disk = DiskHandle::new();
     let gauge = meter
         .u64_observable_gauge("DiskStat")
@@ -19,125 +23,139 @@ pub fn start(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge
             for stat in disks {
                 // TODO
                 let name = Cow::from(stat.name);
-                gauge.observe(
-                    stat.reads,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "reads"),
-                    ],
-                );
-                gauge.observe(
-                    stat.merged,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "merged"),
-                    ],
-                );
-                gauge.observe(
-                    stat.sectors_read,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "sectors_read"),
-                    ],
-                );
-                gauge.observe(
-                    stat.time_reading,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "time_reading"),
-                    ],
-                );
-                gauge.observe(
-                    stat.writes,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "writes"),
-                    ],
-                );
-                gauge.observe(
-                    stat.writes_merged,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "writes_merged"),
-                    ],
-                );
-                gauge.observe(
-                    stat.sectors_written,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "sectors_written"),
-                    ],
-                );
-                gauge.observe(
-                    stat.time_writing,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "time_writing"),
-                    ],
-                );
-                gauge.observe(
-                    stat.in_progress,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "in_progress"),
-                    ],
-                );
-                gauge.observe(
-                    stat.time_in_progress,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "time_in_progress"),
-                    ],
-                );
-                gauge.observe(
-                    stat.weighted_time_in_progress,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "weighted_time_in_progress"),
-                    ],
-                );
-                gauge.observe(
-                    stat.discards.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "discards"),
-                    ],
-                );
-                gauge.observe(
-                    stat.discards_merged.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "discards_merged"),
-                    ],
-                );
-                gauge.observe(
-                    stat.sectors_discarded.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "sectors_discarded"),
-                    ],
-                );
-                gauge.observe(
-                    stat.time_discarding.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "time_discarding"),
-                    ],
-                );
-                gauge.observe(
-                    stat.flushes.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "flushes"),
-                    ],
-                );
-                gauge.observe(
-                    stat.time_flushing.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "time_flushing"),
-                    ],
-                );
+
+                let gauges = [
+                    (
+                        stat.reads,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "reads"),
+                        ],
+                    ),
+                    (
+                        stat.merged,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "merged"),
+                        ],
+                    ),
+                    (
+                        stat.sectors_read,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "sectors_read"),
+                        ],
+                    ),
+                    (
+                        stat.time_reading,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "time_reading"),
+                        ],
+                    ),
+                    (
+                        stat.writes,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "writes"),
+                        ],
+                    ),
+                    (
+                        stat.writes_merged,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "writes_merged"),
+                        ],
+                    ),
+                    (
+                        stat.sectors_written,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "sectors_written"),
+                        ],
+                    ),
+                    (
+                        stat.time_writing,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "time_writing"),
+                        ],
+                    ),
+                    (
+                        stat.in_progress,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "in_progress"),
+                        ],
+                    ),
+                    (
+                        stat.time_in_progress,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "time_in_progress"),
+                        ],
+                    ),
+                    (
+                        stat.weighted_time_in_progress,
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "weighted_time_in_progress"),
+                        ],
+                    ),
+                    (
+                        stat.discards.unwrap_or(0),
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "discards"),
+                        ],
+                    ),
+                    (
+                        stat.discards_merged.unwrap_or(0),
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "discards_merged"),
+                        ],
+                    ),
+                    (
+                        stat.sectors_discarded.unwrap_or(0),
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "sectors_discarded"),
+                        ],
+                    ),
+                    (
+                        stat.time_discarding.unwrap_or(0),
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "time_discarding"),
+                        ],
+                    ),
+                    (
+                        stat.flushes.unwrap_or(0),
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "flushes"),
+                        ],
+                    ),
+                    (
+                        stat.time_flushing.unwrap_or(0),
+                        [
+                            KeyValue::new("disk", name.clone()),
+                            KeyValue::new("stat", "time_flushing"),
+                        ],
+                    ),
+                ];
+
+                if let Some(instance_id) = &instance_id {
+                    gauges.into_iter().for_each(|(m, [kv1, kv2])| {
+                        let a = &[KeyValue::new("instance_id", instance_id.clone()), kv1, kv2];
+                        gauge.observe(m, a);
+                    })
+                } else {
+                    gauges.into_iter().for_each(|(m, a)| {
+                        gauge.observe(m, &a);
+                    })
+                }
             }
         })
         .try_init()?;

--- a/src/otlp/gauges/interrupt.rs
+++ b/src/otlp/gauges/interrupt.rs
@@ -1,0 +1,35 @@
+use std::{borrow::Cow, time::Duration};
+
+use opentelemetry::{
+    metrics::{Meter, ObservableGauge},
+    KeyValue,
+};
+use psh_system::interrupt::InterruptHandle;
+
+pub fn start(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
+    let interrupt = InterruptHandle::new();
+    let gauge = meter
+        .u64_observable_gauge("InterruptStat")
+        .with_description("System profile interrupt statistics.")
+        // .with_unit(Unit::new("KiB"))
+        .with_callback(move |gauge| {
+            let Ok(irqs) = interrupt.stat(Some(interval)) else {
+                return;
+            };
+            for int in irqs {
+                // TODO
+                let desc = Cow::from(int.description);
+                for (cpu, &cnt) in int.cpu_counts.iter().enumerate() {
+                    gauge.observe(
+                        cnt,
+                        &[
+                            KeyValue::new("desc", desc.clone()),
+                            KeyValue::new("cpu", cpu as i64),
+                        ],
+                    )
+                }
+            }
+        })
+        .try_init()?;
+    Ok(gauge)
+}

--- a/src/otlp/gauges/memory.rs
+++ b/src/otlp/gauges/memory.rs
@@ -6,8 +6,13 @@ use opentelemetry::{
 };
 use psh_system::memory::MemoryHandle;
 
-pub fn start(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
+pub fn start(
+    instance_id: Option<String>,
+    meter: Meter,
+    interval: Duration,
+) -> anyhow::Result<ObservableGauge<u64>> {
     let memory = MemoryHandle::new();
+
     let gauge = meter
         .u64_observable_gauge("MemoryStat")
         .with_description("System profile memory statistics.")
@@ -16,107 +21,113 @@ pub fn start(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge
             let Ok(mem) = memory.stat(Some(interval)) else {
                 return;
             };
-            gauge.observe(mem.mem_total, &[KeyValue::new("stat", "mem_total")]);
-            gauge.observe(mem.mem_free, &[KeyValue::new("stat", "mem_free")]);
-            gauge.observe(mem.mem_available, &[KeyValue::new("stat", "mem_available")]);
-            gauge.observe(mem.buffers, &[KeyValue::new("stat", "buffers")]);
-            gauge.observe(mem.cached, &[KeyValue::new("stat", "cached")]);
-            gauge.observe(mem.swap_cached, &[KeyValue::new("stat", "swap_cached")]);
-            gauge.observe(mem.active, &[KeyValue::new("stat", "active")]);
-            gauge.observe(mem.inactive, &[KeyValue::new("stat", "inactive")]);
-            gauge.observe(mem.active_anon, &[KeyValue::new("stat", "active_anon")]);
-            gauge.observe(mem.inactive_anon, &[KeyValue::new("stat", "inactive_anon")]);
-            gauge.observe(mem.active_file, &[KeyValue::new("stat", "active_file")]);
-            gauge.observe(mem.inactive_file, &[KeyValue::new("stat", "inactive_file")]);
-            gauge.observe(mem.unevictable, &[KeyValue::new("stat", "unevictable")]);
-            gauge.observe(mem.mlocked, &[KeyValue::new("stat", "mlocked")]);
-            gauge.observe(mem.swap_total, &[KeyValue::new("stat", "swap_total")]);
-            gauge.observe(mem.swap_free, &[KeyValue::new("stat", "swap_free")]);
-            gauge.observe(mem.dirty, &[KeyValue::new("stat", "dirty")]);
-            gauge.observe(mem.writeback, &[KeyValue::new("stat", "writeback")]);
-            gauge.observe(mem.anon_pages, &[KeyValue::new("stat", "anon_pages")]);
-            gauge.observe(mem.mapped, &[KeyValue::new("stat", "mapped")]);
-            gauge.observe(mem.shmem, &[KeyValue::new("stat", "shmem")]);
-            gauge.observe(mem.kreclaimable, &[KeyValue::new("stat", "kreclaimable")]);
-            gauge.observe(mem.slab, &[KeyValue::new("stat", "slab")]);
-            gauge.observe(mem.sreclaimable, &[KeyValue::new("stat", "sreclaimable")]);
-            gauge.observe(mem.sunreclaim, &[KeyValue::new("stat", "sunreclaim")]);
-            gauge.observe(mem.kernel_stack, &[KeyValue::new("stat", "kernel_stack")]);
-            gauge.observe(mem.page_tables, &[KeyValue::new("stat", "page_tables")]);
-            gauge.observe(mem.nfs_unstable, &[KeyValue::new("stat", "nfs_unstable")]);
-            gauge.observe(mem.bounce, &[KeyValue::new("stat", "bounce")]);
-            gauge.observe(mem.writeback_tmp, &[KeyValue::new("stat", "writeback_tmp")]);
-            gauge.observe(mem.commit_limit, &[KeyValue::new("stat", "commit_limit")]);
-            gauge.observe(mem.committed_as, &[KeyValue::new("stat", "committed_as")]);
-            gauge.observe(mem.vmalloc_total, &[KeyValue::new("stat", "vmalloc_total")]);
-            gauge.observe(mem.vmalloc_used, &[KeyValue::new("stat", "vmalloc_used")]);
-            gauge.observe(mem.vmalloc_chunk, &[KeyValue::new("stat", "vmalloc_chunk")]);
-            gauge.observe(mem.percpu, &[KeyValue::new("stat", "percpu")]);
-            gauge.observe(
-                mem.cma_total.unwrap_or(0),
-                &[KeyValue::new("stat", "cma_total")],
-            );
-            gauge.observe(
-                mem.cma_free.unwrap_or(0),
-                &[KeyValue::new("stat", "cma_free")],
-            );
-            gauge.observe(
-                mem.hardware_corrupted.unwrap_or(0),
-                &[KeyValue::new("stat", "hardware_corrupted")],
-            );
-            gauge.observe(
-                mem.anon_huge_pages.unwrap_or(0),
-                &[KeyValue::new("stat", "anon_huge_pages")],
-            );
-            gauge.observe(
-                mem.shmem_huge_pages.unwrap_or(0),
-                &[KeyValue::new("stat", "shmem_huge_pages")],
-            );
-            gauge.observe(
-                mem.shmem_pmd_mapped.unwrap_or(0),
-                &[KeyValue::new("stat", "shmem_pmd_mapped")],
-            );
-            gauge.observe(
-                mem.file_huge_pages.unwrap_or(0),
-                &[KeyValue::new("stat", "file_huge_pages")],
-            );
-            gauge.observe(
-                mem.file_pmd_mapped.unwrap_or(0),
-                &[KeyValue::new("stat", "file_pmd_mapped")],
-            );
-            gauge.observe(
-                mem.huge_pages_total,
-                &[KeyValue::new("stat", "huge_pages_total")],
-            );
-            gauge.observe(
-                mem.huge_pages_free,
-                &[KeyValue::new("stat", "huge_pages_free")],
-            );
-            gauge.observe(
-                mem.huge_pages_rsvd,
-                &[KeyValue::new("stat", "huge_pages_rsvd")],
-            );
-            gauge.observe(
-                mem.huge_pages_surp,
-                &[KeyValue::new("stat", "huge_pages_surp")],
-            );
-            gauge.observe(
-                mem.huge_page_size,
-                &[KeyValue::new("stat", "huge_page_size")],
-            );
-            gauge.observe(mem.huge_tlb, &[KeyValue::new("stat", "huge_tlb")]);
-            gauge.observe(
-                mem.direct_map4k.unwrap_or(0),
-                &[KeyValue::new("stat", "direct_map4k")],
-            );
-            gauge.observe(
-                mem.direct_map2_m.unwrap_or(0),
-                &[KeyValue::new("stat", "direct_map2_m")],
-            );
-            gauge.observe(
-                mem.direct_map1_g.unwrap_or(0),
-                &[KeyValue::new("stat", "direct_map1_g")],
-            );
+            let gauges = [
+                (mem.mem_total, KeyValue::new("stat", "mem_total")),
+                (mem.mem_free, KeyValue::new("stat", "mem_free")),
+                (mem.mem_available, KeyValue::new("stat", "mem_available")),
+                (mem.buffers, KeyValue::new("stat", "buffers")),
+                (mem.cached, KeyValue::new("stat", "cached")),
+                (mem.swap_cached, KeyValue::new("stat", "swap_cached")),
+                (mem.active, KeyValue::new("stat", "active")),
+                (mem.inactive, KeyValue::new("stat", "inactive")),
+                (mem.active_anon, KeyValue::new("stat", "active_anon")),
+                (mem.inactive_anon, KeyValue::new("stat", "inactive_anon")),
+                (mem.active_file, KeyValue::new("stat", "active_file")),
+                (mem.inactive_file, KeyValue::new("stat", "inactive_file")),
+                (mem.unevictable, KeyValue::new("stat", "unevictable")),
+                (mem.mlocked, KeyValue::new("stat", "mlocked")),
+                (mem.swap_total, KeyValue::new("stat", "swap_total")),
+                (mem.swap_free, KeyValue::new("stat", "swap_free")),
+                (mem.dirty, KeyValue::new("stat", "dirty")),
+                (mem.writeback, KeyValue::new("stat", "writeback")),
+                (mem.anon_pages, KeyValue::new("stat", "anon_pages")),
+                (mem.mapped, KeyValue::new("stat", "mapped")),
+                (mem.shmem, KeyValue::new("stat", "shmem")),
+                (mem.kreclaimable, KeyValue::new("stat", "kreclaimable")),
+                (mem.slab, KeyValue::new("stat", "slab")),
+                (mem.sreclaimable, KeyValue::new("stat", "sreclaimable")),
+                (mem.sunreclaim, KeyValue::new("stat", "sunreclaim")),
+                (mem.kernel_stack, KeyValue::new("stat", "kernel_stack")),
+                (mem.page_tables, KeyValue::new("stat", "page_tables")),
+                (mem.nfs_unstable, KeyValue::new("stat", "nfs_unstable")),
+                (mem.bounce, KeyValue::new("stat", "bounce")),
+                (mem.writeback_tmp, KeyValue::new("stat", "writeback_tmp")),
+                (mem.commit_limit, KeyValue::new("stat", "commit_limit")),
+                (mem.committed_as, KeyValue::new("stat", "committed_as")),
+                (mem.vmalloc_total, KeyValue::new("stat", "vmalloc_total")),
+                (mem.vmalloc_used, KeyValue::new("stat", "vmalloc_used")),
+                (mem.vmalloc_chunk, KeyValue::new("stat", "vmalloc_chunk")),
+                (mem.percpu, KeyValue::new("stat", "percpu")),
+                (
+                    mem.cma_total.unwrap_or(0),
+                    KeyValue::new("stat", "cma_total"),
+                ),
+                (mem.cma_free.unwrap_or(0), KeyValue::new("stat", "cma_free")),
+                (
+                    mem.hardware_corrupted.unwrap_or(0),
+                    KeyValue::new("stat", "hardware_corrupted"),
+                ),
+                (
+                    mem.anon_huge_pages.unwrap_or(0),
+                    KeyValue::new("stat", "anon_huge_pages"),
+                ),
+                (
+                    mem.shmem_huge_pages.unwrap_or(0),
+                    KeyValue::new("stat", "shmem_huge_pages"),
+                ),
+                (
+                    mem.shmem_pmd_mapped.unwrap_or(0),
+                    KeyValue::new("stat", "shmem_pmd_mapped"),
+                ),
+                (
+                    mem.file_huge_pages.unwrap_or(0),
+                    KeyValue::new("stat", "file_huge_pages"),
+                ),
+                (
+                    mem.file_pmd_mapped.unwrap_or(0),
+                    KeyValue::new("stat", "file_pmd_mapped"),
+                ),
+                (
+                    mem.huge_pages_total,
+                    KeyValue::new("stat", "huge_pages_total"),
+                ),
+                (
+                    mem.huge_pages_free,
+                    KeyValue::new("stat", "huge_pages_free"),
+                ),
+                (
+                    mem.huge_pages_rsvd,
+                    KeyValue::new("stat", "huge_pages_rsvd"),
+                ),
+                (
+                    mem.huge_pages_surp,
+                    KeyValue::new("stat", "huge_pages_surp"),
+                ),
+                (mem.huge_page_size, KeyValue::new("stat", "huge_page_size")),
+                (mem.huge_tlb, KeyValue::new("stat", "huge_tlb")),
+                (
+                    mem.direct_map4k.unwrap_or(0),
+                    KeyValue::new("stat", "direct_map4k"),
+                ),
+                (
+                    mem.direct_map2_m.unwrap_or(0),
+                    KeyValue::new("stat", "direct_map2_m"),
+                ),
+                (
+                    mem.direct_map1_g.unwrap_or(0),
+                    KeyValue::new("stat", "direct_map1_g"),
+                ),
+            ];
+
+            if let Some(instance_id) = &instance_id {
+                gauges.into_iter().for_each(|(m, kv)| {
+                    gauge.observe(m, &[KeyValue::new("instance_id", instance_id.clone()), kv]);
+                })
+            } else {
+                gauges.into_iter().for_each(|(m, kv)| {
+                    gauge.observe(m, &[kv]);
+                })
+            }
         })
         .try_init()?;
     Ok(gauge)

--- a/src/otlp/gauges/memory.rs
+++ b/src/otlp/gauges/memory.rs
@@ -1,0 +1,123 @@
+use std::time::Duration;
+
+use opentelemetry::{
+    metrics::{Meter, ObservableGauge},
+    KeyValue,
+};
+use psh_system::memory::MemoryHandle;
+
+pub fn start(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
+    let memory = MemoryHandle::new();
+    let gauge = meter
+        .u64_observable_gauge("MemoryStat")
+        .with_description("System profile memory statistics.")
+        // .with_unit(Unit::new("KiB"))
+        .with_callback(move |gauge| {
+            let Ok(mem) = memory.stat(Some(interval)) else {
+                return;
+            };
+            gauge.observe(mem.mem_total, &[KeyValue::new("stat", "mem_total")]);
+            gauge.observe(mem.mem_free, &[KeyValue::new("stat", "mem_free")]);
+            gauge.observe(mem.mem_available, &[KeyValue::new("stat", "mem_available")]);
+            gauge.observe(mem.buffers, &[KeyValue::new("stat", "buffers")]);
+            gauge.observe(mem.cached, &[KeyValue::new("stat", "cached")]);
+            gauge.observe(mem.swap_cached, &[KeyValue::new("stat", "swap_cached")]);
+            gauge.observe(mem.active, &[KeyValue::new("stat", "active")]);
+            gauge.observe(mem.inactive, &[KeyValue::new("stat", "inactive")]);
+            gauge.observe(mem.active_anon, &[KeyValue::new("stat", "active_anon")]);
+            gauge.observe(mem.inactive_anon, &[KeyValue::new("stat", "inactive_anon")]);
+            gauge.observe(mem.active_file, &[KeyValue::new("stat", "active_file")]);
+            gauge.observe(mem.inactive_file, &[KeyValue::new("stat", "inactive_file")]);
+            gauge.observe(mem.unevictable, &[KeyValue::new("stat", "unevictable")]);
+            gauge.observe(mem.mlocked, &[KeyValue::new("stat", "mlocked")]);
+            gauge.observe(mem.swap_total, &[KeyValue::new("stat", "swap_total")]);
+            gauge.observe(mem.swap_free, &[KeyValue::new("stat", "swap_free")]);
+            gauge.observe(mem.dirty, &[KeyValue::new("stat", "dirty")]);
+            gauge.observe(mem.writeback, &[KeyValue::new("stat", "writeback")]);
+            gauge.observe(mem.anon_pages, &[KeyValue::new("stat", "anon_pages")]);
+            gauge.observe(mem.mapped, &[KeyValue::new("stat", "mapped")]);
+            gauge.observe(mem.shmem, &[KeyValue::new("stat", "shmem")]);
+            gauge.observe(mem.kreclaimable, &[KeyValue::new("stat", "kreclaimable")]);
+            gauge.observe(mem.slab, &[KeyValue::new("stat", "slab")]);
+            gauge.observe(mem.sreclaimable, &[KeyValue::new("stat", "sreclaimable")]);
+            gauge.observe(mem.sunreclaim, &[KeyValue::new("stat", "sunreclaim")]);
+            gauge.observe(mem.kernel_stack, &[KeyValue::new("stat", "kernel_stack")]);
+            gauge.observe(mem.page_tables, &[KeyValue::new("stat", "page_tables")]);
+            gauge.observe(mem.nfs_unstable, &[KeyValue::new("stat", "nfs_unstable")]);
+            gauge.observe(mem.bounce, &[KeyValue::new("stat", "bounce")]);
+            gauge.observe(mem.writeback_tmp, &[KeyValue::new("stat", "writeback_tmp")]);
+            gauge.observe(mem.commit_limit, &[KeyValue::new("stat", "commit_limit")]);
+            gauge.observe(mem.committed_as, &[KeyValue::new("stat", "committed_as")]);
+            gauge.observe(mem.vmalloc_total, &[KeyValue::new("stat", "vmalloc_total")]);
+            gauge.observe(mem.vmalloc_used, &[KeyValue::new("stat", "vmalloc_used")]);
+            gauge.observe(mem.vmalloc_chunk, &[KeyValue::new("stat", "vmalloc_chunk")]);
+            gauge.observe(mem.percpu, &[KeyValue::new("stat", "percpu")]);
+            gauge.observe(
+                mem.cma_total.unwrap_or(0),
+                &[KeyValue::new("stat", "cma_total")],
+            );
+            gauge.observe(
+                mem.cma_free.unwrap_or(0),
+                &[KeyValue::new("stat", "cma_free")],
+            );
+            gauge.observe(
+                mem.hardware_corrupted.unwrap_or(0),
+                &[KeyValue::new("stat", "hardware_corrupted")],
+            );
+            gauge.observe(
+                mem.anon_huge_pages.unwrap_or(0),
+                &[KeyValue::new("stat", "anon_huge_pages")],
+            );
+            gauge.observe(
+                mem.shmem_huge_pages.unwrap_or(0),
+                &[KeyValue::new("stat", "shmem_huge_pages")],
+            );
+            gauge.observe(
+                mem.shmem_pmd_mapped.unwrap_or(0),
+                &[KeyValue::new("stat", "shmem_pmd_mapped")],
+            );
+            gauge.observe(
+                mem.file_huge_pages.unwrap_or(0),
+                &[KeyValue::new("stat", "file_huge_pages")],
+            );
+            gauge.observe(
+                mem.file_pmd_mapped.unwrap_or(0),
+                &[KeyValue::new("stat", "file_pmd_mapped")],
+            );
+            gauge.observe(
+                mem.huge_pages_total,
+                &[KeyValue::new("stat", "huge_pages_total")],
+            );
+            gauge.observe(
+                mem.huge_pages_free,
+                &[KeyValue::new("stat", "huge_pages_free")],
+            );
+            gauge.observe(
+                mem.huge_pages_rsvd,
+                &[KeyValue::new("stat", "huge_pages_rsvd")],
+            );
+            gauge.observe(
+                mem.huge_pages_surp,
+                &[KeyValue::new("stat", "huge_pages_surp")],
+            );
+            gauge.observe(
+                mem.huge_page_size,
+                &[KeyValue::new("stat", "huge_page_size")],
+            );
+            gauge.observe(mem.huge_tlb, &[KeyValue::new("stat", "huge_tlb")]);
+            gauge.observe(
+                mem.direct_map4k.unwrap_or(0),
+                &[KeyValue::new("stat", "direct_map4k")],
+            );
+            gauge.observe(
+                mem.direct_map2_m.unwrap_or(0),
+                &[KeyValue::new("stat", "direct_map2_m")],
+            );
+            gauge.observe(
+                mem.direct_map1_g.unwrap_or(0),
+                &[KeyValue::new("stat", "direct_map1_g")],
+            );
+        })
+        .try_init()?;
+    Ok(gauge)
+}

--- a/src/otlp/gauges/mod.rs
+++ b/src/otlp/gauges/mod.rs
@@ -1,0 +1,1 @@
+pub mod memory;

--- a/src/otlp/gauges/mod.rs
+++ b/src/otlp/gauges/mod.rs
@@ -1,2 +1,3 @@
+pub mod disk;
 pub mod memory;
 pub mod network;

--- a/src/otlp/gauges/mod.rs
+++ b/src/otlp/gauges/mod.rs
@@ -1,1 +1,2 @@
 pub mod memory;
+pub mod network;

--- a/src/otlp/gauges/mod.rs
+++ b/src/otlp/gauges/mod.rs
@@ -1,3 +1,4 @@
 pub mod disk;
+pub mod interrupt;
 pub mod memory;
 pub mod network;

--- a/src/otlp/gauges/network.rs
+++ b/src/otlp/gauges/network.rs
@@ -6,7 +6,11 @@ use opentelemetry::{
 };
 use psh_system::network::NetworkHandle;
 
-pub fn start(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
+pub fn start(
+    instance_id: Option<String>,
+    meter: Meter,
+    interval: Duration,
+) -> anyhow::Result<ObservableGauge<u64>> {
     let network = NetworkHandle::new();
     let gauge = meter
         .u64_observable_gauge("NetworkStat")
@@ -19,118 +23,132 @@ pub fn start(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge
             for (dev, status) in stat {
                 // TODO
                 let dev = Cow::from(dev);
-                gauge.observe(
-                    status.recv_bytes,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_bytes"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_packets,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_packets"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_errs,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_errs"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_drop,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_drop"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_fifo,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_fifo"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_frame,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_frame"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_compressed,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_compressed"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_multicast,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_multicast"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_bytes,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_bytes"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_packets,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_packets"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_errs,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_errs"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_drop,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_drop"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_fifo,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_fifo"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_colls,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_colls"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_carrier,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_carrier"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_compressed,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_compressed"),
-                    ],
-                );
+
+                let gauges = [
+                    (
+                        status.recv_bytes,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "recv_bytes"),
+                        ],
+                    ),
+                    (
+                        status.recv_packets,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "recv_packets"),
+                        ],
+                    ),
+                    (
+                        status.recv_errs,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "recv_errs"),
+                        ],
+                    ),
+                    (
+                        status.recv_drop,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "recv_drop"),
+                        ],
+                    ),
+                    (
+                        status.recv_fifo,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "recv_fifo"),
+                        ],
+                    ),
+                    (
+                        status.recv_frame,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "recv_frame"),
+                        ],
+                    ),
+                    (
+                        status.recv_compressed,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "recv_compressed"),
+                        ],
+                    ),
+                    (
+                        status.recv_multicast,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "recv_multicast"),
+                        ],
+                    ),
+                    (
+                        status.sent_bytes,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "sent_bytes"),
+                        ],
+                    ),
+                    (
+                        status.sent_packets,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "sent_packets"),
+                        ],
+                    ),
+                    (
+                        status.sent_errs,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "sent_errs"),
+                        ],
+                    ),
+                    (
+                        status.sent_drop,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "sent_drop"),
+                        ],
+                    ),
+                    (
+                        status.sent_fifo,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "sent_fifo"),
+                        ],
+                    ),
+                    (
+                        status.sent_colls,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "sent_colls"),
+                        ],
+                    ),
+                    (
+                        status.sent_carrier,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "sent_carrier"),
+                        ],
+                    ),
+                    (
+                        status.sent_compressed,
+                        [
+                            KeyValue::new("interface", dev.clone()),
+                            KeyValue::new("stat", "sent_compressed"),
+                        ],
+                    ),
+                ];
+
+                if let Some(instance_id) = &instance_id {
+                    gauges.into_iter().for_each(|(m, [kv1, kv2])| {
+                        let a = [KeyValue::new("instance_id", instance_id.clone()), kv1, kv2];
+                        gauge.observe(m, &a);
+                    })
+                } else {
+                    gauges.into_iter().for_each(|(m, a)| {
+                        gauge.observe(m, &a);
+                    })
+                }
             }
         })
         .try_init()?;

--- a/src/otlp/gauges/network.rs
+++ b/src/otlp/gauges/network.rs
@@ -1,0 +1,138 @@
+use std::{borrow::Cow, time::Duration};
+
+use opentelemetry::{
+    metrics::{Meter, ObservableGauge},
+    KeyValue,
+};
+use psh_system::network::NetworkHandle;
+
+pub fn start(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
+    let network = NetworkHandle::new();
+    let gauge = meter
+        .u64_observable_gauge("NetworkStat")
+        .with_description("System profile network statistics.")
+        // .with_unit(Unit::new("KiB"))
+        .with_callback(move |gauge| {
+            let Ok(stat) = network.stat(Some(interval)) else {
+                return;
+            };
+            for (dev, status) in stat {
+                // TODO
+                let dev = Cow::from(dev);
+                gauge.observe(
+                    status.recv_bytes,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "recv_bytes"),
+                    ],
+                );
+                gauge.observe(
+                    status.recv_packets,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "recv_packets"),
+                    ],
+                );
+                gauge.observe(
+                    status.recv_errs,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "recv_errs"),
+                    ],
+                );
+                gauge.observe(
+                    status.recv_drop,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "recv_drop"),
+                    ],
+                );
+                gauge.observe(
+                    status.recv_fifo,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "recv_fifo"),
+                    ],
+                );
+                gauge.observe(
+                    status.recv_frame,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "recv_frame"),
+                    ],
+                );
+                gauge.observe(
+                    status.recv_compressed,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "recv_compressed"),
+                    ],
+                );
+                gauge.observe(
+                    status.recv_multicast,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "recv_multicast"),
+                    ],
+                );
+                gauge.observe(
+                    status.sent_bytes,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "sent_bytes"),
+                    ],
+                );
+                gauge.observe(
+                    status.sent_packets,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "sent_packets"),
+                    ],
+                );
+                gauge.observe(
+                    status.sent_errs,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "sent_errs"),
+                    ],
+                );
+                gauge.observe(
+                    status.sent_drop,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "sent_drop"),
+                    ],
+                );
+                gauge.observe(
+                    status.sent_fifo,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "sent_fifo"),
+                    ],
+                );
+                gauge.observe(
+                    status.sent_colls,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "sent_colls"),
+                    ],
+                );
+                gauge.observe(
+                    status.sent_carrier,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "sent_carrier"),
+                    ],
+                );
+                gauge.observe(
+                    status.sent_compressed,
+                    &[
+                        KeyValue::new("interface", dev.clone()),
+                        KeyValue::new("stat", "sent_compressed"),
+                    ],
+                );
+            }
+        })
+        .try_init()?;
+    Ok(gauge)
+}

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -36,11 +36,15 @@ pub fn meter_provider(export_config: ExportConfig, token: String) -> Result<SdkM
         .map_err(Into::into)
 }
 
-pub async fn otlp_tasks(export_config: ExportConfig, token: String) -> anyhow::Result<()> {
+pub async fn otlp_tasks(
+    instance_id: Option<String>,
+    export_config: ExportConfig,
+    token: String,
+) -> anyhow::Result<()> {
     let provider = meter_provider(export_config, token)?;
     let meter = provider.meter("SystemProfile");
     let interval = Duration::from_secs(1);
-    let _ = gauges::memory::start(meter.clone(), interval)?;
+    let _ = gauges::memory::start(instance_id.clone(), meter.clone(), interval)?;
     let _ = gauges::network::start(meter.clone(), interval)?;
     let _ = gauges::disk::start(meter.clone(), interval)?;
     let _ = gauges::interrupt::start(meter.clone(), interval)?;

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -16,7 +16,7 @@ use opentelemetry_sdk::{
     },
     runtime, Resource,
 };
-use psh_system::{disk::DiskHandle, interrupt::InterruptHandle};
+use psh_system::interrupt::InterruptHandle;
 use tonic::{metadata::MetadataMap, transport::ClientTlsConfig};
 
 pub fn meter_provider(export_config: ExportConfig, token: String) -> Result<SdkMeterProvider> {
@@ -38,144 +38,6 @@ pub fn meter_provider(export_config: ExportConfig, token: String) -> Result<SdkM
         .with_temporality_selector(DefaultTemporalitySelector::new())
         .build()
         .map_err(Into::into)
-}
-
-pub fn otlp_disks(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
-    let disk = DiskHandle::new();
-    let gauge = meter
-        .u64_observable_gauge("DiskStat")
-        .with_description("System profile disk statistics.")
-        // .with_unit(Unit::new("KiB"))
-        .with_callback(move |gauge| {
-            let Ok(disks) = disk.stat(Some(interval)) else {
-                return;
-            };
-            for stat in disks {
-                // TODO
-                let name = Cow::from(stat.name);
-                gauge.observe(
-                    stat.reads,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "reads"),
-                    ],
-                );
-                gauge.observe(
-                    stat.merged,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "merged"),
-                    ],
-                );
-                gauge.observe(
-                    stat.sectors_read,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "sectors_read"),
-                    ],
-                );
-                gauge.observe(
-                    stat.time_reading,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "time_reading"),
-                    ],
-                );
-                gauge.observe(
-                    stat.writes,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "writes"),
-                    ],
-                );
-                gauge.observe(
-                    stat.writes_merged,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "writes_merged"),
-                    ],
-                );
-                gauge.observe(
-                    stat.sectors_written,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "sectors_written"),
-                    ],
-                );
-                gauge.observe(
-                    stat.time_writing,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "time_writing"),
-                    ],
-                );
-                gauge.observe(
-                    stat.in_progress,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "in_progress"),
-                    ],
-                );
-                gauge.observe(
-                    stat.time_in_progress,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "time_in_progress"),
-                    ],
-                );
-                gauge.observe(
-                    stat.weighted_time_in_progress,
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "weighted_time_in_progress"),
-                    ],
-                );
-                gauge.observe(
-                    stat.discards.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "discards"),
-                    ],
-                );
-                gauge.observe(
-                    stat.discards_merged.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "discards_merged"),
-                    ],
-                );
-                gauge.observe(
-                    stat.sectors_discarded.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "sectors_discarded"),
-                    ],
-                );
-                gauge.observe(
-                    stat.time_discarding.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "time_discarding"),
-                    ],
-                );
-                gauge.observe(
-                    stat.flushes.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "flushes"),
-                    ],
-                );
-                gauge.observe(
-                    stat.time_flushing.unwrap_or(0),
-                    &[
-                        KeyValue::new("disk", name.clone()),
-                        KeyValue::new("stat", "time_flushing"),
-                    ],
-                );
-            }
-        })
-        .try_init()?;
-    Ok(gauge)
 }
 
 pub fn otlp_interrupt(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
@@ -212,7 +74,7 @@ pub async fn otlp_tasks(export_config: ExportConfig, token: String) -> anyhow::R
     let interval = Duration::from_secs(1);
     let _ = gauges::memory::start(meter.clone(), interval)?;
     let _ = gauges::network::start(meter.clone(), interval)?;
-    let _ = otlp_disks(meter.clone(), interval)?;
+    let _ = gauges::disk::start(meter.clone(), interval)?;
     let _ = otlp_interrupt(meter.clone(), interval)?;
     loop {
         tokio::time::sleep(interval).await;

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -45,7 +45,7 @@ pub async fn otlp_tasks(
     let meter = provider.meter("SystemProfile");
     let interval = Duration::from_secs(1);
     let _ = gauges::memory::start(instance_id.clone(), meter.clone(), interval)?;
-    let _ = gauges::network::start(meter.clone(), interval)?;
+    let _ = gauges::network::start(instance_id.clone(), meter.clone(), interval)?;
     let _ = gauges::disk::start(instance_id.clone(), meter.clone(), interval)?;
     let _ = gauges::interrupt::start(meter.clone(), interval)?;
     loop {

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod gauges;
 
 use std::{borrow::Cow, time::Duration};
 
@@ -15,9 +16,7 @@ use opentelemetry_sdk::{
     },
     runtime, Resource,
 };
-use psh_system::{
-    disk::DiskHandle, interrupt::InterruptHandle, memory::MemoryHandle, network::NetworkHandle,
-};
+use psh_system::{disk::DiskHandle, interrupt::InterruptHandle, network::NetworkHandle};
 use tonic::{metadata::MetadataMap, transport::ClientTlsConfig};
 
 pub fn meter_provider(export_config: ExportConfig, token: String) -> Result<SdkMeterProvider> {
@@ -39,122 +38,6 @@ pub fn meter_provider(export_config: ExportConfig, token: String) -> Result<SdkM
         .with_temporality_selector(DefaultTemporalitySelector::new())
         .build()
         .map_err(Into::into)
-}
-
-pub fn otlp_memories(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
-    let memory = MemoryHandle::new();
-    let gauge = meter
-        .u64_observable_gauge("MemoryStat")
-        .with_description("System profile memory statistics.")
-        // .with_unit(Unit::new("KiB"))
-        .with_callback(move |gauge| {
-            let Ok(mem) = memory.stat(Some(interval)) else {
-                return;
-            };
-            gauge.observe(mem.mem_total, &[KeyValue::new("stat", "mem_total")]);
-            gauge.observe(mem.mem_free, &[KeyValue::new("stat", "mem_free")]);
-            gauge.observe(mem.mem_available, &[KeyValue::new("stat", "mem_available")]);
-            gauge.observe(mem.buffers, &[KeyValue::new("stat", "buffers")]);
-            gauge.observe(mem.cached, &[KeyValue::new("stat", "cached")]);
-            gauge.observe(mem.swap_cached, &[KeyValue::new("stat", "swap_cached")]);
-            gauge.observe(mem.active, &[KeyValue::new("stat", "active")]);
-            gauge.observe(mem.inactive, &[KeyValue::new("stat", "inactive")]);
-            gauge.observe(mem.active_anon, &[KeyValue::new("stat", "active_anon")]);
-            gauge.observe(mem.inactive_anon, &[KeyValue::new("stat", "inactive_anon")]);
-            gauge.observe(mem.active_file, &[KeyValue::new("stat", "active_file")]);
-            gauge.observe(mem.inactive_file, &[KeyValue::new("stat", "inactive_file")]);
-            gauge.observe(mem.unevictable, &[KeyValue::new("stat", "unevictable")]);
-            gauge.observe(mem.mlocked, &[KeyValue::new("stat", "mlocked")]);
-            gauge.observe(mem.swap_total, &[KeyValue::new("stat", "swap_total")]);
-            gauge.observe(mem.swap_free, &[KeyValue::new("stat", "swap_free")]);
-            gauge.observe(mem.dirty, &[KeyValue::new("stat", "dirty")]);
-            gauge.observe(mem.writeback, &[KeyValue::new("stat", "writeback")]);
-            gauge.observe(mem.anon_pages, &[KeyValue::new("stat", "anon_pages")]);
-            gauge.observe(mem.mapped, &[KeyValue::new("stat", "mapped")]);
-            gauge.observe(mem.shmem, &[KeyValue::new("stat", "shmem")]);
-            gauge.observe(mem.kreclaimable, &[KeyValue::new("stat", "kreclaimable")]);
-            gauge.observe(mem.slab, &[KeyValue::new("stat", "slab")]);
-            gauge.observe(mem.sreclaimable, &[KeyValue::new("stat", "sreclaimable")]);
-            gauge.observe(mem.sunreclaim, &[KeyValue::new("stat", "sunreclaim")]);
-            gauge.observe(mem.kernel_stack, &[KeyValue::new("stat", "kernel_stack")]);
-            gauge.observe(mem.page_tables, &[KeyValue::new("stat", "page_tables")]);
-            gauge.observe(mem.nfs_unstable, &[KeyValue::new("stat", "nfs_unstable")]);
-            gauge.observe(mem.bounce, &[KeyValue::new("stat", "bounce")]);
-            gauge.observe(mem.writeback_tmp, &[KeyValue::new("stat", "writeback_tmp")]);
-            gauge.observe(mem.commit_limit, &[KeyValue::new("stat", "commit_limit")]);
-            gauge.observe(mem.committed_as, &[KeyValue::new("stat", "committed_as")]);
-            gauge.observe(mem.vmalloc_total, &[KeyValue::new("stat", "vmalloc_total")]);
-            gauge.observe(mem.vmalloc_used, &[KeyValue::new("stat", "vmalloc_used")]);
-            gauge.observe(mem.vmalloc_chunk, &[KeyValue::new("stat", "vmalloc_chunk")]);
-            gauge.observe(mem.percpu, &[KeyValue::new("stat", "percpu")]);
-            gauge.observe(
-                mem.cma_total.unwrap_or(0),
-                &[KeyValue::new("stat", "cma_total")],
-            );
-            gauge.observe(
-                mem.cma_free.unwrap_or(0),
-                &[KeyValue::new("stat", "cma_free")],
-            );
-            gauge.observe(
-                mem.hardware_corrupted.unwrap_or(0),
-                &[KeyValue::new("stat", "hardware_corrupted")],
-            );
-            gauge.observe(
-                mem.anon_huge_pages.unwrap_or(0),
-                &[KeyValue::new("stat", "anon_huge_pages")],
-            );
-            gauge.observe(
-                mem.shmem_huge_pages.unwrap_or(0),
-                &[KeyValue::new("stat", "shmem_huge_pages")],
-            );
-            gauge.observe(
-                mem.shmem_pmd_mapped.unwrap_or(0),
-                &[KeyValue::new("stat", "shmem_pmd_mapped")],
-            );
-            gauge.observe(
-                mem.file_huge_pages.unwrap_or(0),
-                &[KeyValue::new("stat", "file_huge_pages")],
-            );
-            gauge.observe(
-                mem.file_pmd_mapped.unwrap_or(0),
-                &[KeyValue::new("stat", "file_pmd_mapped")],
-            );
-            gauge.observe(
-                mem.huge_pages_total,
-                &[KeyValue::new("stat", "huge_pages_total")],
-            );
-            gauge.observe(
-                mem.huge_pages_free,
-                &[KeyValue::new("stat", "huge_pages_free")],
-            );
-            gauge.observe(
-                mem.huge_pages_rsvd,
-                &[KeyValue::new("stat", "huge_pages_rsvd")],
-            );
-            gauge.observe(
-                mem.huge_pages_surp,
-                &[KeyValue::new("stat", "huge_pages_surp")],
-            );
-            gauge.observe(
-                mem.huge_page_size,
-                &[KeyValue::new("stat", "huge_page_size")],
-            );
-            gauge.observe(mem.huge_tlb, &[KeyValue::new("stat", "huge_tlb")]);
-            gauge.observe(
-                mem.direct_map4k.unwrap_or(0),
-                &[KeyValue::new("stat", "direct_map4k")],
-            );
-            gauge.observe(
-                mem.direct_map2_m.unwrap_or(0),
-                &[KeyValue::new("stat", "direct_map2_m")],
-            );
-            gauge.observe(
-                mem.direct_map1_g.unwrap_or(0),
-                &[KeyValue::new("stat", "direct_map1_g")],
-            );
-        })
-        .try_init()?;
-    Ok(gauge)
 }
 
 pub fn otlp_networks(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
@@ -458,7 +341,7 @@ pub async fn otlp_tasks(export_config: ExportConfig, token: String) -> anyhow::R
     let provider = meter_provider(export_config, token)?;
     let meter = provider.meter("SystemProfile");
     let interval = Duration::from_secs(1);
-    let _ = otlp_memories(meter.clone(), interval)?;
+    let _ = gauges::memory::start(meter.clone(), interval)?;
     let _ = otlp_networks(meter.clone(), interval)?;
     let _ = otlp_disks(meter.clone(), interval)?;
     let _ = otlp_interrupt(meter.clone(), interval)?;

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -46,7 +46,7 @@ pub async fn otlp_tasks(
     let interval = Duration::from_secs(1);
     let _ = gauges::memory::start(instance_id.clone(), meter.clone(), interval)?;
     let _ = gauges::network::start(meter.clone(), interval)?;
-    let _ = gauges::disk::start(meter.clone(), interval)?;
+    let _ = gauges::disk::start(instance_id.clone(), meter.clone(), interval)?;
     let _ = gauges::interrupt::start(meter.clone(), interval)?;
     loop {
         tokio::time::sleep(interval).await;

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -16,7 +16,7 @@ use opentelemetry_sdk::{
     },
     runtime, Resource,
 };
-use psh_system::{disk::DiskHandle, interrupt::InterruptHandle, network::NetworkHandle};
+use psh_system::{disk::DiskHandle, interrupt::InterruptHandle};
 use tonic::{metadata::MetadataMap, transport::ClientTlsConfig};
 
 pub fn meter_provider(export_config: ExportConfig, token: String) -> Result<SdkMeterProvider> {
@@ -38,137 +38,6 @@ pub fn meter_provider(export_config: ExportConfig, token: String) -> Result<SdkM
         .with_temporality_selector(DefaultTemporalitySelector::new())
         .build()
         .map_err(Into::into)
-}
-
-pub fn otlp_networks(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
-    let network = NetworkHandle::new();
-    let gauge = meter
-        .u64_observable_gauge("NetworkStat")
-        .with_description("System profile network statistics.")
-        // .with_unit(Unit::new("KiB"))
-        .with_callback(move |gauge| {
-            let Ok(stat) = network.stat(Some(interval)) else {
-                return;
-            };
-            for (dev, status) in stat {
-                // TODO
-                let dev = Cow::from(dev);
-                gauge.observe(
-                    status.recv_bytes,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_bytes"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_packets,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_packets"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_errs,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_errs"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_drop,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_drop"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_fifo,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_fifo"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_frame,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_frame"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_compressed,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_compressed"),
-                    ],
-                );
-                gauge.observe(
-                    status.recv_multicast,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "recv_multicast"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_bytes,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_bytes"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_packets,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_packets"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_errs,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_errs"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_drop,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_drop"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_fifo,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_fifo"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_colls,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_colls"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_carrier,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_carrier"),
-                    ],
-                );
-                gauge.observe(
-                    status.sent_compressed,
-                    &[
-                        KeyValue::new("interface", dev.clone()),
-                        KeyValue::new("stat", "sent_compressed"),
-                    ],
-                );
-            }
-        })
-        .try_init()?;
-    Ok(gauge)
 }
 
 pub fn otlp_disks(meter: Meter, interval: Duration) -> anyhow::Result<ObservableGauge<u64>> {
@@ -342,7 +211,7 @@ pub async fn otlp_tasks(export_config: ExportConfig, token: String) -> anyhow::R
     let meter = provider.meter("SystemProfile");
     let interval = Duration::from_secs(1);
     let _ = gauges::memory::start(meter.clone(), interval)?;
-    let _ = otlp_networks(meter.clone(), interval)?;
+    let _ = gauges::network::start(meter.clone(), interval)?;
     let _ = otlp_disks(meter.clone(), interval)?;
     let _ = otlp_interrupt(meter.clone(), interval)?;
     loop {

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -47,7 +47,7 @@ pub async fn otlp_tasks(
     let _ = gauges::memory::start(instance_id.clone(), meter.clone(), interval)?;
     let _ = gauges::network::start(instance_id.clone(), meter.clone(), interval)?;
     let _ = gauges::disk::start(instance_id.clone(), meter.clone(), interval)?;
-    let _ = gauges::interrupt::start(meter.clone(), interval)?;
+    let _ = gauges::interrupt::start(instance_id, meter.clone(), interval)?;
     loop {
         tokio::time::sleep(interval).await;
     }

--- a/src/services/host_info.rs
+++ b/src/services/host_info.rs
@@ -73,7 +73,7 @@ pub struct RawInfo {
 }
 
 impl RawInfo {
-    const INSTANCE_ID_FILE: &'static str = "/etc/psh/instance.id";
+    pub const INSTANCE_ID_FILE: &'static str = "/etc/psh/instance.id";
 
     pub fn new() -> Self {
         let hostname = nix::unistd::gethostname()


### PR DESCRIPTION
PSH will get an `instance_id` when it communicates with the remote RPC server for the first time. We can use this id to distinguish different PSH instance data in TSDB.