### PR TITLE
Identify PSH by `token` instead of `instance_id`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,12 +24,7 @@ mod security;
 mod services;
 mod utils;
 
-use std::{
-    fs::{self},
-    process::exit,
-    result::Result::Ok,
-    thread::JoinHandle,
-};
+use std::{process::exit, result::Result::Ok, thread::JoinHandle};
 
 use anyhow::{Context, Error, Result};
 use args::Args;
@@ -41,7 +36,7 @@ use runtime::PshEngineBuilder;
 use utils::check_root_privilege;
 
 use otlp::config::OtlpConfig;
-use services::{config::RpcConfig, host_info::RawInfo, rpc::RpcClient};
+use services::{config::RpcConfig, rpc::RpcClient};
 
 fn main() -> Result<()> {
     log_init();
@@ -109,10 +104,7 @@ fn async_tasks(
             let otlp_task = async {
                 if otlp_conf.enable() {
                     let export_conf: ExportConfig = otlp_conf.into();
-                    let instance_id = fs::read_to_string(RawInfo::INSTANCE_ID_FILE)
-                        .map(Some)
-                        .unwrap_or(None);
-                    otlp::otlp_tasks(instance_id, export_conf, token).await?;
+                    otlp::otlp_tasks(export_conf, token).await?;
                 }
                 Ok::<(), Error>(())
             };

--- a/src/otlp/gauges/disk.rs
+++ b/src/otlp/gauges/disk.rs
@@ -7,7 +7,7 @@ use opentelemetry::{
 use psh_system::disk::DiskHandle;
 
 pub fn start(
-    instance_id: Option<String>,
+    token: String,
     meter: Meter,
     interval: Duration,
 ) -> anyhow::Result<ObservableGauge<u64>> {
@@ -146,16 +146,10 @@ pub fn start(
                     ),
                 ];
 
-                if let Some(instance_id) = &instance_id {
-                    gauges.into_iter().for_each(|(m, [kv1, kv2])| {
-                        let a = &[KeyValue::new("instance_id", instance_id.clone()), kv1, kv2];
-                        gauge.observe(m, a);
-                    })
-                } else {
-                    gauges.into_iter().for_each(|(m, a)| {
-                        gauge.observe(m, &a);
-                    })
-                }
+                gauges.into_iter().for_each(|(m, [kv1, kv2])| {
+                    let a = &[KeyValue::new("token", token.clone()), kv1, kv2];
+                    gauge.observe(m, a);
+                });
             }
         })
         .try_init()?;

--- a/src/otlp/gauges/interrupt.rs
+++ b/src/otlp/gauges/interrupt.rs
@@ -7,7 +7,7 @@ use opentelemetry::{
 use psh_system::interrupt::InterruptHandle;
 
 pub fn start(
-    instance_id: Option<String>,
+    token: String,
     meter: Meter,
     interval: Duration,
 ) -> anyhow::Result<ObservableGauge<u64>> {
@@ -24,20 +24,12 @@ pub fn start(
                 // TODO
                 let desc = Cow::from(int.description);
                 for (cpu, &cnt) in int.cpu_counts.iter().enumerate() {
-                    if let Some(instance_id) = &instance_id {
-                        let a = [
-                            KeyValue::new("instance_id", instance_id.clone()),
-                            KeyValue::new("desc", desc.clone()),
-                            KeyValue::new("cpu", cpu as i64),
-                        ];
-                        gauge.observe(cnt, &a)
-                    } else {
-                        let a = [
-                            KeyValue::new("desc", desc.clone()),
-                            KeyValue::new("cpu", cpu as i64),
-                        ];
-                        gauge.observe(cnt, &a)
-                    };
+                    let a = [
+                        KeyValue::new("token", token.clone()),
+                        KeyValue::new("desc", desc.clone()),
+                        KeyValue::new("cpu", cpu as i64),
+                    ];
+                    gauge.observe(cnt, &a)
                 }
             }
         })

--- a/src/otlp/gauges/memory.rs
+++ b/src/otlp/gauges/memory.rs
@@ -7,7 +7,7 @@ use opentelemetry::{
 use psh_system::memory::MemoryHandle;
 
 pub fn start(
-    instance_id: Option<String>,
+    token: String,
     meter: Meter,
     interval: Duration,
 ) -> anyhow::Result<ObservableGauge<u64>> {
@@ -119,15 +119,9 @@ pub fn start(
                 ),
             ];
 
-            if let Some(instance_id) = &instance_id {
-                gauges.into_iter().for_each(|(m, kv)| {
-                    gauge.observe(m, &[KeyValue::new("instance_id", instance_id.clone()), kv]);
-                })
-            } else {
-                gauges.into_iter().for_each(|(m, kv)| {
-                    gauge.observe(m, &[kv]);
-                })
-            }
+            gauges.into_iter().for_each(|(m, kv)| {
+                gauge.observe(m, &[KeyValue::new("token", token.clone()), kv]);
+            })
         })
         .try_init()?;
     Ok(gauge)

--- a/src/otlp/gauges/network.rs
+++ b/src/otlp/gauges/network.rs
@@ -7,7 +7,7 @@ use opentelemetry::{
 use psh_system::network::NetworkHandle;
 
 pub fn start(
-    instance_id: Option<String>,
+    token: String,
     meter: Meter,
     interval: Duration,
 ) -> anyhow::Result<ObservableGauge<u64>> {
@@ -139,16 +139,10 @@ pub fn start(
                     ),
                 ];
 
-                if let Some(instance_id) = &instance_id {
-                    gauges.into_iter().for_each(|(m, [kv1, kv2])| {
-                        let a = [KeyValue::new("instance_id", instance_id.clone()), kv1, kv2];
-                        gauge.observe(m, &a);
-                    })
-                } else {
-                    gauges.into_iter().for_each(|(m, a)| {
-                        gauge.observe(m, &a);
-                    })
-                }
+                gauges.into_iter().for_each(|(m, [kv1, kv2])| {
+                    let a = [KeyValue::new("token", token.clone()), kv1, kv2];
+                    gauge.observe(m, &a);
+                })
             }
         })
         .try_init()?;

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -36,18 +36,14 @@ pub fn meter_provider(export_config: ExportConfig, token: String) -> Result<SdkM
         .map_err(Into::into)
 }
 
-pub async fn otlp_tasks(
-    instance_id: Option<String>,
-    export_config: ExportConfig,
-    token: String,
-) -> anyhow::Result<()> {
-    let provider = meter_provider(export_config, token)?;
+pub async fn otlp_tasks(export_config: ExportConfig, token: String) -> anyhow::Result<()> {
+    let provider = meter_provider(export_config, token.clone())?;
     let meter = provider.meter("SystemProfile");
     let interval = Duration::from_secs(1);
-    let _ = gauges::memory::start(instance_id.clone(), meter.clone(), interval)?;
-    let _ = gauges::network::start(instance_id.clone(), meter.clone(), interval)?;
-    let _ = gauges::disk::start(instance_id.clone(), meter.clone(), interval)?;
-    let _ = gauges::interrupt::start(instance_id, meter.clone(), interval)?;
+    let _ = gauges::memory::start(token.clone(), meter.clone(), interval)?;
+    let _ = gauges::network::start(token.clone(), meter.clone(), interval)?;
+    let _ = gauges::disk::start(token.clone(), meter.clone(), interval)?;
+    let _ = gauges::interrupt::start(token, meter.clone(), interval)?;
     loop {
         tokio::time::sleep(interval).await;
     }


### PR DESCRIPTION
Since each PSH has a unique token, we can use the token to identify the PSH in the shared otel-collector. Identification by instance ID is fine, but using the token we can do more in the remote server.