### PR TITLE
Merge `otlp` config and `rpc` config into `remote` config

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,10 +31,16 @@ pub struct PshConfig {
     auth: AuthConfig,
     #[serde(rename = "component")]
     component_conf: ComponentConfig,
-    #[serde(rename = "otlp")]
-    otlp_conf: OtlpConfig,
     daemon: DaemonConfig,
-    rpc: RpcConfig,
+    pub remote: RemoteConfig,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteConfig {
+    pub enable: bool,
+    pub rpc: RpcConfig,
+    #[serde(rename = "otlp")]
+    pub otlp_conf: OtlpConfig,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -77,13 +83,17 @@ impl PshConfig {
         daemon: DaemonConfig,
         rpc: RpcConfig,
         auth: AuthConfig,
+        enable_remote: bool,
     ) -> Self {
         Self {
             component_conf,
-            otlp_conf,
             daemon,
-            rpc,
             auth,
+            remote: RemoteConfig {
+                enable: enable_remote,
+                rpc,
+                otlp_conf,
+            },
         }
     }
 
@@ -121,7 +131,7 @@ impl PshConfig {
     }
 
     pub fn otlp_conf(&mut self) -> OtlpConfig {
-        mem::take(&mut self.otlp_conf)
+        mem::take(&mut self.remote.otlp_conf)
     }
 
     pub fn get_component_args(&mut self) -> Vec<String> {
@@ -133,7 +143,7 @@ impl PshConfig {
     }
 
     pub fn rpc(&mut self) -> RpcConfig {
-        mem::take(&mut self.rpc)
+        mem::take(&mut self.remote.rpc)
     }
 
     pub fn take_token(&mut self) -> String {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -167,25 +167,26 @@ token = ""
 path = "cpu.wasm"
 args = ["1", "2", "3"]
 
-[otlp]
-enable = true
-endpoint = "http://localhost:4317"
-protocol = "Grpc"
-
-[otlp.timeout]
-secs = 3
-nanos = 0
-
 [daemon]
 pid_file = "/tmp/psh.pid"
 stdout_file = "/tmp/psh.stdout"
 stderr_file = "/tmp/psh.stderr"
 working_directory = "/"
 
-[rpc]
+[remote]
 enable = true
+
+[remote.rpc]
 addr = ""
 duration = 1
+
+[remote.otlp]
+endpoint = "http://localhost:4317"
+protocol = "Grpc"
+
+[remote.otlp.timeout]
+secs = 3
+nanos = 0
 "#;
 
     const TEST_CONF_PATH: &str = "./target/config.toml";
@@ -201,6 +202,7 @@ duration = 1
             DaemonConfig::default(),
             RpcConfig::default(),
             AuthConfig::default(),
+            true,
         );
         let s = toml::to_string(&cf).unwrap();
         assert_eq!(s, CONFIG_STR);
@@ -220,6 +222,7 @@ duration = 1
             DaemonConfig::default(),
             RpcConfig::default(),
             AuthConfig::default(),
+            false,
         );
         cf.generate_config(TEST_CONF_PATH, true).unwrap();
         let conf = PshConfig::read_config(TEST_CONF_PATH).unwrap();

--- a/src/otlp/config.rs
+++ b/src/otlp/config.rs
@@ -19,7 +19,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OtlpConfig {
-    enable: bool,
     endpoint: String,
     timeout: Duration,
     protocol: String,
@@ -28,7 +27,6 @@ pub struct OtlpConfig {
 impl Default for OtlpConfig {
     fn default() -> Self {
         Self {
-            enable: true,
             endpoint: "http://localhost:4317".to_owned(),
             timeout: Duration::from_secs(3),
             protocol: "Grpc".to_owned(),
@@ -37,17 +35,12 @@ impl Default for OtlpConfig {
 }
 
 impl OtlpConfig {
-    pub fn new(enable: bool, endpoint: String, timeout: Duration, protocol: String) -> Self {
+    pub fn new(endpoint: String, timeout: Duration, protocol: String) -> Self {
         Self {
-            enable,
             endpoint,
             timeout,
             protocol,
         }
-    }
-
-    pub fn enable(&self) -> bool {
-        self.enable
     }
 }
 

--- a/src/otlp/config.rs
+++ b/src/otlp/config.rs
@@ -87,8 +87,7 @@ mod tests {
 
     use super::*;
 
-    const CONF_STR_SECS_NANO: &str = r#"enable = true
-endpoint = "http://localhost:7878"
+    const CONF_STR_SECS_NANO: &str = r#"endpoint = "http://localhost:7878"
 protocol = "HttpJson"
 
 [timeout]
@@ -96,8 +95,7 @@ secs = 2
 nanos = 20
 "#;
 
-    const CONF_STR_SECS: &str = r#"enable = true
-endpoint = "http://localhost:4317"
+    const CONF_STR_SECS: &str = r#"endpoint = "http://localhost:4317"
 protocol = "Grpc"
 
 [timeout]
@@ -108,7 +106,6 @@ nanos = 0
     #[test]
     fn otlp_conf_to_str() {
         let cf = OtlpConfig::new(
-            true,
             "http://localhost:4317".to_owned(),
             Duration::from_secs(3),
             "Grpc".to_owned(),
@@ -118,7 +115,6 @@ nanos = 0
         assert_eq!(s, CONF_STR_SECS);
 
         let cf = OtlpConfig::new(
-            true,
             "http://localhost:7878".to_owned(),
             Duration::new(2, 20),
             "HttpJson".to_owned(),
@@ -130,9 +126,7 @@ nanos = 0
 
     #[test]
     fn str_to_otlp_conf() {
-        let conf_str: &str = r#"enable = true
-
-endpoint = "http://localhost:4317"
+        let conf_str: &str = r#"endpoint = "http://localhost:4317"
 
 protocol = "Grpc"
 
@@ -155,7 +149,6 @@ nanos = 0
         }
 
         let cf = OtlpConfig::new(
-            true,
             "http://localhost:4317".to_owned(),
             Duration::from_secs(3),
             "Grpc".to_owned(),
@@ -169,7 +162,6 @@ nanos = 0
         test_it(conf_str, &cf, &export_config);
 
         let cf = OtlpConfig::new(
-            true,
             "http://localhost:7878".to_owned(),
             Duration::new(2, 20),
             "HttpJson".to_owned(),

--- a/src/services/config.rs
+++ b/src/services/config.rs
@@ -16,7 +16,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RpcConfig {
-    pub enable: bool,
     pub addr: String,
     pub duration: u64,
 }
@@ -24,7 +23,6 @@ pub struct RpcConfig {
 impl Default for RpcConfig {
     fn default() -> Self {
         Self {
-            enable: true,
             addr: String::new(),
             duration: 1,
         }


### PR DESCRIPTION
The otlp and rpc should both be enabled or disabled, merging them into the `remote` config to achieve this.