### PR TITLE
Scheduling WASM components through `TaskRuntime`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ mod security;
 mod services;
 mod utils;
 
-use std::{process::exit, result::Result::Ok, thread::JoinHandle};
+use std::{fs, process::exit, result::Result::Ok, thread::JoinHandle};
 
 use anyhow::{Context, Error, Result};
 use args::Args;
@@ -81,7 +81,9 @@ fn main() -> Result<()> {
             .build()
             .context("Failed to build PshEngine.")?;
 
-        engine.run(&component_args[0])?;
+        let binary = fs::read(&component_args[0])?;
+
+        engine.run(&binary)?;
     }
 
     let _ = async_handle.map(|it| it.join());

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,13 +26,13 @@ mod utils;
 
 use std::{fs, process::exit, result::Result::Ok, thread::JoinHandle};
 
-use anyhow::{Context, Error, Result};
+use anyhow::{Error, Result};
 use args::Args;
 use clap::Parser;
 use config::PshConfig;
 use log::log_init;
 use opentelemetry_otlp::ExportConfig;
-use runtime::PshEngineBuilder;
+use runtime::{Task, TaskRuntime};
 use utils::check_root_privilege;
 
 use otlp::config::OtlpConfig;
@@ -60,7 +60,6 @@ fn main() -> Result<()> {
     } else {
         args.get_component_args()
     };
-    let component_envs: Vec<(String, String)> = std::env::vars().collect();
 
     if args.daemon() {
         daemon::Daemon::new(psh_config.daemon().clone()).daemon()?;
@@ -71,22 +70,23 @@ fn main() -> Result<()> {
         .enable
         .then(|| async_tasks(rpc_conf, otlp_conf, psh_config.take_token()));
 
-    if let Some(component_args) = component_args {
-        let mut engine = PshEngineBuilder::new()
-            .wasi_inherit_stdio()
-            .wasi_envs(&component_envs)
-            .wasi_args(&component_args)
-            .allow_perf_op(true)
-            .allow_system_op(true)
-            .build()
-            .context("Failed to build PshEngine.")?;
+    let mut task_rt = TaskRuntime::new()?;
 
-        let binary = fs::read(&component_args[0])?;
+    if let Some(args) = component_args {
+        let task = Task {
+            wasm_component: fs::read(&args[0])?,
+            wasm_component_args: args,
+        };
+        task_rt.schedule(task)?;
+    };
 
-        engine.run(&binary)?;
+    let task_handle = task_rt.spawn()?;
+    if let Some(async_handle) = async_handle {
+        let _ = async_handle.join();
+    } else {
+        drop(task_rt);
     }
-
-    let _ = async_handle.map(|it| it.join());
+    let _ = task_handle.join();
 
     Ok(())
 }

--- a/src/runtime/engine/mod.rs
+++ b/src/runtime/engine/mod.rs
@@ -12,8 +12,6 @@
 // You should have received a copy of the GNU Lesser General Public License along with Performance Savior Home (PSH). If not,
 // see <https://www.gnu.org/licenses/>.
 
-use std::path::Path;
-
 use anyhow::Context;
 use wasmtime::{
     component::{Component, Linker},
@@ -30,9 +28,9 @@ pub struct PshEngine {
 }
 
 impl PshEngine {
-    pub fn run(&mut self, path: impl AsRef<Path>) -> anyhow::Result<()> {
+    pub fn run(&mut self, binary: &[u8]) -> anyhow::Result<()> {
         let component =
-            Component::from_file(&self.engine, path).context("Failed to read component file!")?;
+            Component::from_binary(&self.engine, binary).context("Failed to load component!")?;
         let (cmd, _inst) = Command::instantiate(&mut self.store, &component, &self.linker)
             .context("Failed to instantiate Wasi Command!")?;
         cmd.wasi_cli_run()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -19,6 +19,86 @@ mod state;
 #[cfg(test)]
 mod tests;
 
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc::channel;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+use std::thread;
+use std::thread::JoinHandle;
+
+use anyhow::Context;
+use anyhow::Result;
 pub use builder::PshEngineBuilder;
 pub use engine::PshEngine;
 pub use state::PshState;
+
+pub struct Task {
+    pub wasm_component: Vec<u8>,
+    pub wasm_component_args: Vec<String>,
+}
+
+pub struct TaskRuntime {
+    tx: Sender<Task>,
+    rx: Option<Receiver<Task>>,
+    len: Arc<AtomicUsize>,
+}
+
+impl TaskRuntime {
+    pub fn new() -> Result<Self> {
+        let (tx, rx) = channel();
+
+        Ok(Self {
+            tx,
+            rx: Some(rx),
+            len: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+
+    pub fn schedule(&mut self, task: Task) -> Result<()> {
+        self.len.fetch_add(1, Ordering::Release);
+        self.tx.send(task)?;
+        Ok(())
+    }
+
+    #[expect(dead_code)]
+    pub fn is_idle(&self) -> bool {
+        let len = self.len.load(Ordering::Acquire);
+        len == 0
+    }
+
+    pub fn spawn(&mut self) -> Result<JoinHandle<()>> {
+        let rx = match self.rx.take() {
+            Some(rx) => rx,
+            None => panic!("twice spawned"),
+        };
+
+        let envs: Vec<(String, String)> = std::env::vars().collect();
+
+        let len = self.len.clone();
+        let handle = thread::spawn(move || {
+            while let Ok(task) = rx.recv() {
+                let engine = PshEngineBuilder::new()
+                    .wasi_inherit_stdio()
+                    .wasi_envs(&envs)
+                    .wasi_args(&task.wasm_component_args)
+                    .allow_perf_op(true)
+                    .allow_system_op(true)
+                    .build()
+                    .context("Failed to build PshEngine.");
+
+                match engine {
+                    Ok(mut o) => {
+                        let _ = o.run(&task.wasm_component);
+                    }
+                    Err(e) => eprintln!("{}", e),
+                };
+
+                len.fetch_sub(1, Ordering::Release);
+            }
+        });
+
+        Ok(handle)
+    }
+}

--- a/src/runtime/tests/mod.rs
+++ b/src/runtime/tests/mod.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with Performance Savior Home (PSH). If not,
 // see <https://www.gnu.org/licenses/>.
 
-use std::{path::Path, process::Command};
+use std::{fs, path::Path, process::Command};
 
 use anyhow::Context as _;
 
@@ -50,7 +50,8 @@ fn test_wasm_component(wasm: &str) {
     };
     let path = format!("./test_resources/profiling/{wasm}/target/wasm32-wasi/debug/{wasm}.wasm");
     assert!(Path::new(&path).exists());
-    assert!(engine.run(&path).is_ok());
+    let binary = fs::read(wasm).unwrap();
+    assert!(engine.run(&binary).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
With `TaskRuntime` we can easily schedule WASM components (which we call "task") and find out whether PSH is idle (no tasks to run), which is the foundation for receiving and running tasks via RPC calls from remote server.