### PR TITLE
Fix arg 0 for remote task

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,13 @@ async fn async_tasks(remote_cfg: RemoteConfig, mut task_rt: TaskRuntime) -> Resu
         loop {
             let idle = task_rt.is_idle();
             if idle {
-                if let Some(task) = client.get_task(instance_id.clone()).await? {
+                if let Some(mut task) = client.get_task(instance_id.clone()).await? {
+                    let task_id = task
+                        .id
+                        .as_ref()
+                        .map(|it| it.to_string())
+                        .expect("No task id provided");
+                    task.wasm_component_args.insert(0, task_id);
                     task_rt.schedule(task)?
                 }
             }


### PR DESCRIPTION
The arg 0 of the remote tasks should be the task id, this patch fixes it.
See: https://github.com/OptimatistOpenSource/psh/pull/102