### PR TITLE
Replace std MPSC channel with crossbeam `SegQueue` for `DataExporter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2413,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "crossbeam",
  "daemonize",
  "host-op-perf",
  "host-op-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 daemonize = { workspace = true }
 local-ip-address = { workspace = true }
 TinyUFO = { workspace = true }
+crossbeam = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }
@@ -90,6 +91,7 @@ which = "^6"
 num_cpus = "^1"
 local-ip-address = "^0.6"
 TinyUFO = "0.4"
+crossbeam = "0.8"
 
 [workspace.lints.rust]
 


### PR DESCRIPTION
This patch simplified the `DataExporter` impl with `SegQueue` from crossbeam crate. Since the std MPSC channel is a backport of crossbeam, there is no performance difference with the current impl.
FWIW: https://github.com/rust-lang/rust/pull/93563