### PR TITLE
gRPC: add timeout and retry times for RPC services.

### DIFF
--- a/doc/config.toml
+++ b/doc/config.toml
@@ -18,6 +18,9 @@ addr = "https://api.optimatist.com"
 # in seconds
 heartbeat_interval = 1
 instance_id_file = "/etc/psh/instance.id"
+max_retries = 3
+# in seconds
+base_delay = 1
 
 [remote.rpc.data_export]
 buf_size = 4096

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ use std::{fs, path::Path};
 
 use anyhow::Result;
 use serde::Deserialize;
+use std::time::Duration;
 
 const TEMPLATE: &str = include_str!("../doc/config.toml");
 
@@ -56,6 +57,17 @@ pub struct RpcConfig {
     pub heartbeat_interval: u64,
     pub instance_id_file: String,
     pub data_export: DataExportConfig,
+    pub max_retries: Option<u32>,
+    #[serde(deserialize_with = "deserialize_duration")]
+    pub base_delay: Option<Duration>,
+}
+
+fn deserialize_duration<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let seconds: u64 = serde::Deserialize::deserialize(deserializer)?;
+    Ok(Some(Duration::from_secs(seconds)))
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
To improve the stability of PSH, avoiding psh quite due to network disturbance, added 
timeout configuration and retry times for RPC services. 